### PR TITLE
After died, even when has an interruption, pacman didn't move

### DIFF
--- a/src/pacman_main.asm
+++ b/src/pacman_main.asm
@@ -56,15 +56,27 @@ volta:
   JMP PacMan_movement
 
 PacRight1:
+  LDX pacmanLive
+  CPX #1
+  BNE Forever
   JMP PacRight
 
 PacLeft1:
+  LDX pacmanLive
+  CPX #1
+  BNE Forever
   JMP PacLeft
 
 PacUp1:
+  LDX pacmanLive
+  CPX #1
+  BNE Forever
   JMP PacUp
 
 PacDown1:
+  LDX pacmanLive
+  CPX #1
+  BNE Forever
   JMP PacDown
 
 beep2: ; emite um beep em C# (#$C9)
@@ -82,9 +94,6 @@ beep3: ; emite um beep em C# (#$C9)
   JMP volta
 
 PacMan_movement:
-  LDX pacmanLive
-  CPX #1
-  BNE Forever
   LDA directionPacMan
   CMP #10
   BEQ PacUp1


### PR DESCRIPTION
Tinhamos um bug que após o pacman morrer, caso tivesse alguma interrupção no teclado (W A S D), ele continuava andando (quando a interrupção parava, ele travava novamente).

Adicionei uma comparação antes de todo movimento para checar se o pacman está vivo